### PR TITLE
支持以包装类型替代基本类型

### DIFF
--- a/src/main/java/org/gsonformat/intellij/ConvertBridge.java
+++ b/src/main/java/org/gsonformat/intellij/ConvertBridge.java
@@ -2,22 +2,21 @@ package org.gsonformat.intellij;
 
 import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.ui.MessageType;
 import com.intellij.psi.*;
 import com.intellij.psi.impl.source.PsiClassReferenceType;
+import com.intellij.psi.util.PsiTypesUtil;
 import org.apache.http.util.TextUtils;
 import org.gsonformat.intellij.action.DataWriter;
+import org.gsonformat.intellij.common.CheckUtil;
+import org.gsonformat.intellij.common.PsiClassUtil;
 import org.gsonformat.intellij.common.StringUtils;
 import org.gsonformat.intellij.common.Utils;
 import org.gsonformat.intellij.config.Config;
+import org.gsonformat.intellij.entity.ClassEntity;
 import org.gsonformat.intellij.entity.DataType;
 import org.gsonformat.intellij.entity.FieldEntity;
-import org.gsonformat.intellij.entity.ClassEntity;
-import org.gsonformat.intellij.common.CheckUtil;
-import org.gsonformat.intellij.common.PsiClassUtil;
 import org.gsonformat.intellij.entity.IterableFieldEntity;
 import org.gsonformat.intellij.ui.FieldsDialog;
-import org.gsonformat.intellij.ui.Toast;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -546,7 +545,13 @@ public class ConvertBridge {
         } else {
             FieldEntity fieldEntity = new FieldEntity();
             fieldEntity.setKey(key);
-            fieldEntity.setType(DataType.typeOfObject(type).getValue());
+            String vType;
+            if (Config.getInstant().isUseWrapperClass()) {
+                vType = PsiTypesUtil.boxIfPossible(DataType.getWrapperTypeSimpleName(DataType.typeOfObject(type)));
+            } else {
+                vType = DataType.typeOfObject(type).getValue();
+            }
+            fieldEntity.setType(vType);
             result = fieldEntity;
             if (type != null) {
                 result.setValue(type.toString());

--- a/src/main/java/org/gsonformat/intellij/common/PsiClassUtil.java
+++ b/src/main/java/org/gsonformat/intellij/common/PsiClassUtil.java
@@ -154,7 +154,11 @@ public class PsiClassUtil {
             return null;
         }
         int i = cls.getQualifiedName().lastIndexOf(".");
-        return cls.getQualifiedName().substring(0, i);
+        if (i > -1) {
+            return cls.getQualifiedName().substring(0, i);
+        } else {
+            return "";
+        }
     }
 
     public static boolean isClassAvailableForProject(Project project, String className) {

--- a/src/main/java/org/gsonformat/intellij/common/PsiClassUtil.java
+++ b/src/main/java/org/gsonformat/intellij/common/PsiClassUtil.java
@@ -1,10 +1,7 @@
 package org.gsonformat.intellij.common;
 
 import com.intellij.ide.util.DirectoryUtil;
-import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.fileEditor.FileEditorManager;
-import com.intellij.openapi.module.Module;
-import com.intellij.openapi.module.ModuleUtil;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
 import com.intellij.psi.impl.source.PsiJavaFileImpl;

--- a/src/main/java/org/gsonformat/intellij/config/Config.java
+++ b/src/main/java/org/gsonformat/intellij/config/Config.java
@@ -36,6 +36,11 @@ public class Config {
      */
     private int errorCount;
 
+    /**
+     * 是否使用包装类来替代基本类型
+     */
+    private boolean useWrapperClass;
+
 
     private Config() {
 
@@ -62,6 +67,8 @@ public class Config {
         PropertiesComponent.getInstance().setValue("useFieldNamePrefix", useFieldNamePrefix + "");
         PropertiesComponent.getInstance().setValue("generateComments", generateComments + "");
         PropertiesComponent.getInstance().setValue("splitGenerate", splitGenerate + "");
+        PropertiesComponent.getInstance().setValue("useWrapperClass", useWrapperClass + "");
+
     }
 
     public static Config getInstant() {
@@ -88,6 +95,7 @@ public class Config {
             config.setUseFieldNamePrefix(PropertiesComponent.getInstance().getBoolean("useFieldNamePrefix", false));
             config.setGenerateComments(PropertiesComponent.getInstance().getBoolean("generateComments", true));
             config.setSplitGenerate(PropertiesComponent.getInstance().getBoolean("splitGenerate", false));
+            config.setUseWrapperClass(PropertiesComponent.getInstance().getBoolean("useWrapperClass", false));
 
         }
         return config;
@@ -311,4 +319,11 @@ public class Config {
         save();
     }
 
+    public boolean isUseWrapperClass() {
+        return useWrapperClass;
+    }
+
+    public void setUseWrapperClass(boolean useWrapperClass) {
+        this.useWrapperClass = useWrapperClass;
+    }
 }

--- a/src/main/java/org/gsonformat/intellij/entity/ClassEntity.java
+++ b/src/main/java/org/gsonformat/intellij/entity/ClassEntity.java
@@ -1,6 +1,6 @@
 package org.gsonformat.intellij.entity;
 
-import com.intellij.psi.*;
+import com.intellij.psi.PsiClass;
 import org.apache.http.util.TextUtils;
 import org.gsonformat.intellij.common.CheckUtil;
 import org.jdesktop.swingx.ux.CellProvider;

--- a/src/main/java/org/gsonformat/intellij/entity/DataType.java
+++ b/src/main/java/org/gsonformat/intellij/entity/DataType.java
@@ -79,4 +79,19 @@ public enum DataType {
         return dataType == dataType1;
     }
 
+    public static String getWrapperTypeSimpleName(DataType type) {
+        switch (type) {
+            case Data_Type_Boolean:
+                return "Boolean";
+            case Data_Type_Int:
+                return "Integer";
+            case Data_Type_Double:
+                return "Double";
+            case Data_Type_long:
+                return "Long";
+            default:
+                return type.getValue();
+        }
+    }
+
 }

--- a/src/main/java/org/gsonformat/intellij/process/AutoValueProcessor.java
+++ b/src/main/java/org/gsonformat/intellij/process/AutoValueProcessor.java
@@ -3,12 +3,11 @@ package org.gsonformat.intellij.process;
 import com.intellij.psi.*;
 import org.apache.http.util.TextUtils;
 import org.gsonformat.intellij.common.FieldHelper;
-import org.gsonformat.intellij.common.PsiClassUtil;
 import org.gsonformat.intellij.common.Try;
 import org.gsonformat.intellij.config.Config;
 import org.gsonformat.intellij.config.Constant;
-import org.gsonformat.intellij.entity.FieldEntity;
 import org.gsonformat.intellij.entity.ClassEntity;
+import org.gsonformat.intellij.entity.FieldEntity;
 
 import java.util.regex.Pattern;
 

--- a/src/main/java/org/gsonformat/intellij/process/ClassProcessor.java
+++ b/src/main/java/org/gsonformat/intellij/process/ClassProcessor.java
@@ -1,8 +1,9 @@
 package org.gsonformat.intellij.process;
 
-import com.intellij.psi.*;
-import org.gsonformat.intellij.entity.ConvertLibrary;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElementFactory;
 import org.gsonformat.intellij.entity.ClassEntity;
+import org.gsonformat.intellij.entity.ConvertLibrary;
 
 
 /**

--- a/src/main/java/org/gsonformat/intellij/process/LombokProcessor.java
+++ b/src/main/java/org/gsonformat/intellij/process/LombokProcessor.java
@@ -75,7 +75,7 @@ public class LombokProcessor extends Processor {
         injectAnnotation(factory, generateClass);
     }
 
-    private String generateLombokFieldText(ClassEntity classEntity, FieldEntity fieldEntity,String fixme) {
+    private String generateLombokFieldText(ClassEntity classEntity, FieldEntity fieldEntity, String fixme) {
         fixme = fixme == null ? "" : fixme;
 
         StringBuilder fieldSb = new StringBuilder();

--- a/src/main/java/org/gsonformat/intellij/process/Processor.java
+++ b/src/main/java/org/gsonformat/intellij/process/Processor.java
@@ -1,6 +1,7 @@
 package org.gsonformat.intellij.process;
 
-import com.intellij.psi.*;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElementFactory;
 import com.intellij.psi.codeStyle.JavaCodeStyleManager;
 import org.apache.http.util.TextUtils;
 import org.gsonformat.intellij.common.FieldHelper;
@@ -8,9 +9,9 @@ import org.gsonformat.intellij.common.PsiClassUtil;
 import org.gsonformat.intellij.common.Try;
 import org.gsonformat.intellij.config.Config;
 import org.gsonformat.intellij.config.Constant;
+import org.gsonformat.intellij.entity.ClassEntity;
 import org.gsonformat.intellij.entity.ConvertLibrary;
 import org.gsonformat.intellij.entity.FieldEntity;
-import org.gsonformat.intellij.entity.ClassEntity;
 
 import java.util.HashMap;
 

--- a/src/main/java/org/gsonformat/intellij/ui/FieldsDialog.java
+++ b/src/main/java/org/gsonformat/intellij/ui/FieldsDialog.java
@@ -1,21 +1,21 @@
 package org.gsonformat.intellij.ui;
 
+import cn.vearn.checktreetable.FiledTreeTableModel;
 import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElementFactory;
-import cn.vearn.checktreetable.FiledTreeTableModel;
 import com.intellij.psi.PsiFile;
 import org.gsonformat.intellij.ConvertBridge;
 import org.gsonformat.intellij.action.DataWriter;
+import org.gsonformat.intellij.common.PsiClassUtil;
 import org.gsonformat.intellij.common.StringUtils;
 import org.gsonformat.intellij.config.Config;
-import org.gsonformat.intellij.entity.FieldEntity;
 import org.gsonformat.intellij.entity.ClassEntity;
-import org.gsonformat.intellij.common.PsiClassUtil;
-import org.jdesktop.swingx.ux.CheckTreeTableManager;
+import org.gsonformat.intellij.entity.FieldEntity;
 import org.jdesktop.swingx.JXTreeTable;
 import org.jdesktop.swingx.treetable.DefaultMutableTreeTableNode;
+import org.jdesktop.swingx.ux.CheckTreeTableManager;
 
 import javax.swing.*;
 import javax.swing.event.ListSelectionEvent;

--- a/src/main/java/org/gsonformat/intellij/ui/JsonDialog.java
+++ b/src/main/java/org/gsonformat/intellij/ui/JsonDialog.java
@@ -7,8 +7,8 @@ import com.intellij.psi.PsiFile;
 import com.intellij.psi.impl.source.PsiJavaFileImpl;
 import org.apache.http.util.TextUtils;
 import org.gsonformat.intellij.ConvertBridge;
-import org.gsonformat.intellij.config.Config;
 import org.gsonformat.intellij.common.PsiClassUtil;
+import org.gsonformat.intellij.config.Config;
 import org.json.JSONArray;
 import org.json.JSONObject;
 

--- a/src/main/java/org/gsonformat/intellij/ui/SettingDialog.form
+++ b/src/main/java/org/gsonformat/intellij/ui/SettingDialog.form
@@ -3,7 +3,7 @@
   <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="10" left="10" bottom="10" right="10"/>
     <constraints>
-      <xy x="48" y="54" width="675" height="778"/>
+      <xy x="48" y="54" width="765" height="849"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -205,17 +205,6 @@
                   <text value="reuse bean"/>
                 </properties>
               </component>
-              <component id="70489" class="javax.swing.JCheckBox" binding="useSerializedNameCheckBox">
-                <constraints>
-                  <grid row="18" column="0" row-span="1" col-span="10" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false">
-                    <minimum-size width="-1" height="30"/>
-                    <preferred-size width="-1" height="30"/>
-                  </grid>
-                </constraints>
-                <properties>
-                  <text value="use serializedName "/>
-                </properties>
-              </component>
               <grid id="6d2ba" layout-manager="GridLayoutManager" row-count="1" column-count="7" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
@@ -395,6 +384,28 @@
                 </constraints>
                 <properties>
                   <text value="split generate"/>
+                </properties>
+              </component>
+              <component id="70489" class="javax.swing.JCheckBox" binding="useSerializedNameCheckBox">
+                <constraints>
+                  <grid row="18" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                    <minimum-size width="-1" height="30"/>
+                    <preferred-size width="-1" height="30"/>
+                  </grid>
+                </constraints>
+                <properties>
+                  <text value="use serializedName "/>
+                </properties>
+              </component>
+              <component id="91a84" class="javax.swing.JCheckBox" binding="useWrapperClassCB">
+                <constraints>
+                  <grid row="18" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                    <minimum-size width="-1" height="30"/>
+                    <preferred-size width="-1" height="30"/>
+                  </grid>
+                </constraints>
+                <properties>
+                  <text value="use warpper class "/>
                 </properties>
               </component>
             </children>

--- a/src/main/java/org/gsonformat/intellij/ui/SettingDialog.form
+++ b/src/main/java/org/gsonformat/intellij/ui/SettingDialog.form
@@ -405,7 +405,7 @@
                   </grid>
                 </constraints>
                 <properties>
-                  <text value="use warpper class "/>
+                  <text value="use wrapper class "/>
                 </properties>
               </component>
             </children>

--- a/src/main/java/org/gsonformat/intellij/ui/SettingDialog.java
+++ b/src/main/java/org/gsonformat/intellij/ui/SettingDialog.java
@@ -42,6 +42,7 @@ public class SettingDialog extends JFrame {
     private JCheckBox splitGenerateMode;
     private JRadioButton lombokRB;
     private String annotaionStr;
+    private JCheckBox useWrapperClassCB;
 
     public SettingDialog(Project project) {
         setContentPane(contentPane);
@@ -93,6 +94,7 @@ public class SettingDialog extends JFrame {
         array1Button.setEnabled(arrayFromData1CB.isSelected());
         suffixEdit.setText(Config.getInstant().getSuffixStr());
         splitGenerateMode.setSelected(Config.getInstant().isSplitGenerate());
+        useWrapperClassCB.setSelected(Config.getInstant().isUseWrapperClass());
         objectFromDataCB.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent actionEvent) {
@@ -340,6 +342,7 @@ public class SettingDialog extends JFrame {
         Config.getInstant().setAnnotationStr(annotationFT.getText());
         Config.getInstant().setUseFieldNamePrefix(filedPrefixCB.isSelected());
         Config.getInstant().setSplitGenerate(splitGenerateMode.isSelected());
+        Config.getInstant().setUseWrapperClass(useWrapperClassCB.isSelected());
         Config.getInstant().save();
 
         dispose();


### PR DESCRIPTION
1、增加了use wrapper class选项。
生成实体的时候默认是基本类型，有时候需要用包装类型替代。
2、修改 unnamed package下转换报错的问题 [#86](https://github.com/zzz40500/GsonFormat/issues/86)